### PR TITLE
change .science to .script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,7 +45,7 @@ fi
 read -d '' CONDARCCONTENT << EOF
 channels:
   - https://packages.nnpdf.science/conda-private
-  - https://packages.nnpdf.script/conda
+  - https://packages.nnpdf.science/conda
   - defaults
   - conda-forge
 


### PR DESCRIPTION
don't know whether it is just me that i did something wrong or whether it is an actual typo in the repo, but i need to use .science and not .script in the url