### PR TITLE
Prioritize conda-force over defaults

### DIFF
--- a/README
+++ b/README
@@ -7,9 +7,10 @@ This script does three things:
  following content:
 
 channels:
-  - https://packages.nnpdf.science/conda
-  - defaults
+  - https://packages.nnpdf.science/private
+  - https://packages.nnpdf.science/public
   - conda-forge
+  - defaults
 
  In case the file exists, the script doesn't touch it (as not even
  with conda config is it easy to set the channels in order).

--- a/README
+++ b/README
@@ -7,10 +7,8 @@ This script does three things:
  following content:
 
 channels:
-  - https://packages.nnpdf.science/private
   - https://packages.nnpdf.science/public
   - conda-forge
-  - defaults
 
  In case the file exists, the script doesn't touch it (as not even
  with conda config is it easy to set the channels in order).

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -46,8 +46,8 @@ read -d '' CONDARCCONTENT << EOF
 channels:
   - https://packages.nnpdf.science/private
   - https://packages.nnpdf.science/public
-  - defaults
   - conda-forge
+  - defaults
 
 EOF
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -47,7 +47,6 @@ channels:
   - https://packages.nnpdf.science/private
   - https://packages.nnpdf.science/public
   - conda-forge
-  - defaults
 
 EOF
 


### PR DESCRIPTION
@Zaharid since the docs still mention binary_bootstrap, maybe we should update this.

At some point I switched to using the compiler from the forge channel, though I can't really remember what made me do that...
Also, if we make this change, the main nnpdf repo needs some corresponding updates. 