### PR TITLE
Add libmamba to the bootstrap script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -44,11 +44,10 @@ fi
 
 read -d '' CONDARCCONTENT << EOF
 channels:
-  - https://packages.nnpdf.science/private
   - https://packages.nnpdf.science/public
   - defaults
   - conda-forge
-
+solver: libmamba
 EOF
 
 


### PR DESCRIPTION
Someone who actually uses conda should test this well but if the standard solver cannot even create the package in the CI it won't certainly be able to install it. Some people already complained in the past that it took a very long time and we just said "go use libmamba" so I think it should be the script itself doing it from now on.

Note that I have no idea what the implications of doing this are as I don't use conda myself so feel free to do other modifications to the script which might be needed?

edit: the tests I've done has been running the binary bootstrap with and without the solver line, and done `conda create -n test nnpdf`, without that line, it hangs. With the line, it is able to install the packages.