### PR TITLE
Use automatically miniconda for M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
+The script in this repository is a quick and easy way of installing the latest version of nnpdf into your computer under a conda environment:
+
+```bash
+curl https://raw.githubusercontent.com/NNPDF/binary-bootstrap/master/bootstrap.sh -o bootstrap.sh
+sh bootstrap.sh
+```
+
+and, assuming that the initialization step was accepted in the previous script,
+
+```bash
+conda create -n nnpdf_env nnpdf -y
+conda activate nnpdf_env
+```
+
 This script does three things:
 
- - Download and install conda.
+ - Download and install conda, trying to get the right architecture for the computer. You can run the following in your terminal:
  
  - Set the appropiriate conda channels to install the NNPDF
  dependencies. This is done by writting a ~/.condarc file with the

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -37,7 +37,12 @@ CONDARC="$HOME"/.condarc
 NETRC="$HOME"/.netrc
 
 if [ "$(uname)" == "Darwin" ]; then
-	CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+	if [ "$(uname -m)" == "arm64" ]
+   	then
+		CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
+  	else
+		CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+  	fi
 else
 	CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 fi
@@ -132,15 +137,8 @@ if [ "$SKIP_DOWNLOAD" = false  ]; then
     curl -Lo ${CONDA_FILE} "${CONDA_URL}"
 	echo "Entering conda installer."
 	chmod +x $CONDA_FILE
-
-  	if [ "$(uname -m)" == "arm64" ]
-   	then
-    		# not all packages are available for m1 in conda, when they are we can change to:
-      		# CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
- 		arch -x86_64 bash $CONDA_FILE
-   	else
-		bash $CONDA_FILE
-  	fi
+ 
+ 	bash $CONDA_FILE
    
 	if [ $? == 0 ]; then
 		INSTALLED_CONDA=$YES


### PR DESCRIPTION
With conda packages for M1 for pineappl, fiatlux and lhapdf, it should now be possible to use a standard miniconda installation matching your architecture.
